### PR TITLE
Add credential schema json

### DIFF
--- a/credential-schema.json
+++ b/credential-schema.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "host": {
+            "title": "Host",
+            "type": "string",
+            "description": "The OpenFn host url",
+            "format": "uri",
+            "default": "https://www.openfn.org",
+            "minLength": 1
+        },
+        "projectId": {
+            "title": "Project ID",
+            "type": "string",
+            "description": "Your OpenFn project ID",
+            "minLength": 1
+        },
+        "username": {
+            "title": "Username",
+            "type": "string",
+            "description": "The username to log in to OpenFn",
+            "minLength": 1
+        },
+        "password": {
+            "title": "Password",
+            "type": "string",
+            "description": "The password to log in to OpenFn",
+            "writeOnly": true,
+            "minLength": 1
+        }
+    },
+    "type": "object",
+    "additionalProperties": true,
+    "required": [
+        "host",
+        "username",
+        "password"
+    ]
+}


### PR DESCRIPTION
This is the sample configuration in the Readme of this repo
```
{
  "host": "https://www.openfn.org/",
  "username": "someone@ngo.org",
  "password": "supersecret",
  "projectId": "ID"
}
```
`projectId` doesn't seem to be used in the Adaptor.js file. We should consider removing it or make a good usage of it.